### PR TITLE
swap PPPP and VVVV id templates in usage

### DIFF
--- a/usbreset.c
+++ b/usbreset.c
@@ -173,7 +173,7 @@ int main(int argc, char **argv)
 		dev = find_device(NULL, NULL, NULL, NULL, argv[1]);
 	else {
 		printf("Usage:\n"
-		       "  usbreset PPPP:VVVV - reset by product and vendor id\n"
+		       "  usbreset VVVV:PPPP - reset by vendor and product id\n"
 		       "  usbreset BBB/DDD   - reset by bus and device number\n"
 		       "  usbreset \"Product\" - reset by product name\n\n"
 		       "Devices:\n");


### PR DESCRIPTION
usage help seems not to align with order of vendor and product IDs in usbreset.c:list_devices()

it also seems not to align with the order of IDs from lsusb(1) and/or with the output of usbreset(1) itself:

examples for two WD external disks:

```
$ lsusb -s 003:014 -v
Bus 003 Device 014: ID 1058:1023 Western Digital Technologies, Inc. Elements SE Portable (WDBABV)
Device Descriptor:
  idVendor           0x1058 Western Digital Technologies, Inc.        <- 1058 is Vendor!
  idProduct          0x1023 Elements SE Portable (WDBABV)        <- 1023 is Product
```

```
$ lsusb
Bus 003 Device 014: ID 1058:1023 Western Digital Technologies, Inc. Elements SE Portable (WDBABV)
Bus 004 Device 002: ID 1058:1140 Western Digital Technologies, Inc. My Book Essential (WDBACW)
```

```
$ usbreset
Usage:
  usbreset PPPP:VVVV - reset by product and vendor id   <- seems PPPP and VVVV are swapped
  usbreset BBB/DDD   - reset by bus and device number
  usbreset "Product" - reset by product name

Devices:
  Number 003/014  ID 1058:1023  Elements 1023
  Number 004/002  ID 1058:1140  My Book 1140
```

Signed-off-by: Author Name <authoremail@example.com>